### PR TITLE
Fix CCPM command paths from ccpm/ to .claude/

### DIFF
--- a/.claude/commands/pm/blocked.md
+++ b/.claude/commands/pm/blocked.md
@@ -1,6 +1,6 @@
 ---
-allowed-tools: Bash(bash ccpm/scripts/pm/blocked.sh)
+allowed-tools: Bash(bash .claude/scripts/pm/blocked.sh)
 ---
 
 Output:
-!bash ccpm/scripts/pm/blocked.sh
+!bash .claude/scripts/pm/blocked.sh

--- a/.claude/commands/pm/epic-list.md
+++ b/.claude/commands/pm/epic-list.md
@@ -1,7 +1,7 @@
 ---
-allowed-tools: Bash(bash ccpm/scripts/pm/epic-list.sh)
+allowed-tools: Bash(bash .claude/scripts/pm/epic-list.sh)
 ---
 
 Output:
-!bash ccpm/scripts/pm/epic-list.sh
+!bash .claude/scripts/pm/epic-list.sh
 

--- a/.claude/commands/pm/epic-show.md
+++ b/.claude/commands/pm/epic-show.md
@@ -1,6 +1,6 @@
 ---
-allowed-tools: Bash(bash ccpm/scripts/pm/epic-show.sh $ARGUMENTS)
+allowed-tools: Bash(bash .claude/scripts/pm/epic-show.sh $ARGUMENTS)
 ---
 
 Output:
-!bash ccpm/scripts/pm/epic-show.sh $ARGUMENTS
+!bash .claude/scripts/pm/epic-show.sh $ARGUMENTS

--- a/.claude/commands/pm/epic-status.md
+++ b/.claude/commands/pm/epic-status.md
@@ -1,6 +1,6 @@
 ---
-allowed-tools: Bash(bash ccpm/scripts/pm/epic-status.sh $ARGUMENTS)
+allowed-tools: Bash(bash .claude/scripts/pm/epic-status.sh $ARGUMENTS)
 ---
 
 Output:
-!bash ccpm/scripts/pm/epic-status.sh $ARGUMENTS
+!bash .claude/scripts/pm/epic-status.sh $ARGUMENTS

--- a/.claude/commands/pm/help.md
+++ b/.claude/commands/pm/help.md
@@ -1,6 +1,6 @@
 ---
-allowed-tools: Bash(bash ccpm/scripts/pm/help.sh)
+allowed-tools: Bash(bash .claude/scripts/pm/help.sh)
 ---
 
 Output:
-!bash ccpm/scripts/pm/help.sh
+!bash .claude/scripts/pm/help.sh

--- a/.claude/commands/pm/in-progress.md
+++ b/.claude/commands/pm/in-progress.md
@@ -1,6 +1,6 @@
 ---
-allowed-tools: Bash(bash ccpm/scripts/pm/in-progress.sh)
+allowed-tools: Bash(bash .claude/scripts/pm/in-progress.sh)
 ---
 
 Output:
-!bash ccpm/scripts/pm/in-progress.sh
+!bash .claude/scripts/pm/in-progress.sh

--- a/.claude/commands/pm/init.md
+++ b/.claude/commands/pm/init.md
@@ -1,6 +1,6 @@
 ---
-allowed-tools: Bash(bash ccpm/scripts/pm/init.sh)
+allowed-tools: Bash(bash .claude/scripts/pm/init.sh)
 ---
 
 Output:
-!bash ccpm/scripts/pm/init.sh
+!bash .claude/scripts/pm/init.sh

--- a/.claude/commands/pm/next.md
+++ b/.claude/commands/pm/next.md
@@ -1,6 +1,6 @@
 ---
-allowed-tools: Bash(bash ccpm/scripts/pm/next.sh)
+allowed-tools: Bash(bash .claude/scripts/pm/next.sh)
 ---
 
 Output:
-!bash ccpm/scripts/pm/next.sh
+!bash .claude/scripts/pm/next.sh

--- a/.claude/commands/pm/prd-list.md
+++ b/.claude/commands/pm/prd-list.md
@@ -1,6 +1,6 @@
 ---
-allowed-tools: Bash(bash ccpm/scripts/pm/prd-list.sh)
+allowed-tools: Bash(bash .claude/scripts/pm/prd-list.sh)
 ---
 
 Output:
-!bash ccpm/scripts/pm/prd-list.sh
+!bash .claude/scripts/pm/prd-list.sh

--- a/.claude/commands/pm/prd-status.md
+++ b/.claude/commands/pm/prd-status.md
@@ -1,6 +1,6 @@
 ---
-allowed-tools: Bash(bash ccpm/scripts/pm/prd-status.sh)
+allowed-tools: Bash(bash .claude/scripts/pm/prd-status.sh)
 ---
 
 Output:
-!bash ccpm/scripts/pm/prd-status.sh
+!bash .claude/scripts/pm/prd-status.sh

--- a/.claude/commands/pm/search.md
+++ b/.claude/commands/pm/search.md
@@ -1,6 +1,6 @@
 ---
-allowed-tools: Bash(bash ccpm/scripts/pm/search.sh $ARGUMENTS)
+allowed-tools: Bash(bash .claude/scripts/pm/search.sh $ARGUMENTS)
 ---
 
 Output:
-!bash ccpm/scripts/pm/search.sh $ARGUMENTS
+!bash .claude/scripts/pm/search.sh $ARGUMENTS

--- a/.claude/commands/pm/standup.md
+++ b/.claude/commands/pm/standup.md
@@ -1,6 +1,6 @@
 ---
-allowed-tools: Bash(bash ccpm/scripts/pm/standup.sh)
+allowed-tools: Bash(bash .claude/scripts/pm/standup.sh)
 ---
 
 Output:
-!bash ccpm/scripts/pm/standup.sh
+!bash .claude/scripts/pm/standup.sh

--- a/.claude/commands/pm/status.md
+++ b/.claude/commands/pm/status.md
@@ -1,6 +1,6 @@
 ---
-allowed-tools: Bash(bash ccpm/scripts/pm/status.sh)
+allowed-tools: Bash(bash .claude/scripts/pm/status.sh)
 ---
 
 Output:
-!bash ccpm/scripts/pm/status.sh
+!bash .claude/scripts/pm/status.sh

--- a/.claude/commands/pm/validate.md
+++ b/.claude/commands/pm/validate.md
@@ -1,6 +1,6 @@
 ---
-allowed-tools: Bash(bash ccpm/scripts/pm/validate.sh)
+allowed-tools: Bash(bash .claude/scripts/pm/validate.sh)
 ---
 
 Output:
-!bash ccpm/scripts/pm/validate.sh
+!bash .claude/scripts/pm/validate.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,16 @@
+# CLAUDE.md
+
+> Think carefully and implement the most concise solution that changes as little code as possible.
+
+## Project-Specific Instructions
+
+Add your project-specific instructions here.
+
+## Testing
+
+Always run tests before committing:
+- `npm test` or equivalent for your stack
+
+## Code Style
+
+Follow existing patterns in the codebase.


### PR DESCRIPTION
## Summary
- All 14 PM slash commands referenced `ccpm/scripts/pm/*.sh` but scripts live at `.claude/scripts/pm/*.sh`
- Updated all command definition files to use the correct `.claude/scripts/pm/` path
- Adds `CLAUDE.md` generated by `pm:init`

## Test plan
- [ ] Run `/pm:init` and verify it executes without path errors
- [ ] Run `/pm:status` and verify script runs correctly
- [ ] Run `/pm:help` and verify output displays

🤖 Generated with [Claude Code](https://claude.com/claude-code)