### PR TITLE
Clean up terminal logs for readability

### DIFF
--- a/backend/src/db/client.ts
+++ b/backend/src/db/client.ts
@@ -5,10 +5,7 @@ const globalForPrisma = global as unknown as { prisma: PrismaClient };
 export const prisma =
   globalForPrisma.prisma ??
   new PrismaClient({
-    log:
-      process.env.NODE_ENV === "development"
-        ? ["query", "error", "warn"]
-        : ["error"],
+    log: ["error", "warn"],
   });
 
 if (process.env.NODE_ENV !== "production") {

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -24,7 +24,7 @@ export function ChannelView({ channelId, channelName, projectId }: Props) {
   useEffect(() => {
     apiFetch<Message[]>(`/api/channels/${channelId}/messages?limit=50`)
       .then((msgs) => setMessages(channelId, msgs))
-      .catch(console.error);
+      .catch((err) => console.error("[ChannelView] Failed to load messages:", err));
   }, [channelId, setMessages]);
 
   // Join socket room

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -41,7 +41,7 @@ export function Header() {
       );
       setActiveProject(updated);
     } catch (err) {
-      console.error("Failed to toggle mode:", err);
+      console.error("[Header] Failed to toggle interaction mode:", err);
     }
   };
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -114,7 +114,7 @@ export function Sidebar() {
                     } else {
                       apiFetch<ProjectFull>(`/api/projects/${p.id}`)
                         .then(switchProject)
-                        .catch(console.error);
+                        .catch((err) => console.error("[Sidebar] Failed to load project:", err));
                     }
                   }}
                   className={clsx(


### PR DESCRIPTION
## Summary
- Remove Prisma `query`-level logging that floods the terminal with every SQL statement in dev mode — only `error` and `warn` are kept
- Add `[Module]` prefixes to 3 bare `console.error` calls in the frontend to match backend's logging convention

## Changes
| File | Change |
|------|--------|
| `backend/src/db/client.ts` | Remove `"query"` from Prisma log config |
| `frontend/src/components/chat/ChannelView.tsx` | `.catch(console.error)` → `[ChannelView] Failed to load messages` |
| `frontend/src/components/layout/Header.tsx` | `Failed to toggle mode` → `[Header] Failed to toggle interaction mode` |
| `frontend/src/components/layout/Sidebar.tsx` | `.catch(console.error)` → `[Sidebar] Failed to load project` |

## Test plan
- [ ] Start backend — terminal should no longer show `prisma:query` lines
- [ ] Errors still log with meaningful context when they occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)